### PR TITLE
Provide for custom axis labels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,32 @@ jobs:
         override: true
         components: rustfmt, clippy
 
-    - name: Lint
+    - name: Lint basic
+      env:
+        RUSTFLAGS: -Dwarnings
+      working-directory: ./examples/basic
+      run: cargo clippy
+
+    - name: Format basic
+      working-directory: ./examples/basic
+      run: cargo fmt -- --check
+
+    - name: Lint scatter
+      env:
+        RUSTFLAGS: -Dwarnings
+      working-directory: ./examples/scatter
+      run: cargo clippy
+
+    - name: Format scatter
+      working-directory: ./examples/scatter
+      run: cargo fmt -- --check
+
+    - name: Lint lib
       env:
         RUSTFLAGS: -Dwarnings
       run: cargo clippy
 
-    - name: Format
+    - name: Format lib
       run: cargo fmt -- --check
 
     - name: Test

--- a/README.md
+++ b/README.md
@@ -37,21 +37,23 @@ fn view(&self, _ctx: &Context<Self>) -> yew::Html {
                 name="some-series"
                 data={Rc::clone(&self.data_set)}
                 data_labels={Some(Rc::clone(&self.data_set_labels))}
-                horizontal_scale={self.time.start.timestamp() as f32..self.time.end.timestamp() as f32}
-                horizontal_scale_step={Duration::days(1).num_seconds() as f32}
-                vertical_scale={0.0..5.0}
+                horizontal_scale={Rc::clone(&self.horizontal_axis_scale)}
+                horizontal_scale_step={Duration::days(2).num_seconds() as f32}
+                vertical_scale={Rc::clone(&self.vertical_axis_scale)}
                 x={MARGIN} y={MARGIN} width={WIDTH - (MARGIN * 2)} height={HEIGHT - (MARGIN * 2)} />
 
             <VerticalAxis
                 name="some-y-axis"
                 orientation={vertical_axis::Orientation::Left}
-                scale={0.0..5.0} scale_step={0.5}
+                scale={Rc::clone(&self.vertical_axis_scale)}
                 x1={MARGIN} y1={MARGIN} y2={HEIGHT - MARGIN}
                 tick_len={TICK_LENGTH}
                 title={"Some Y thing".to_string()} />
 
-            <HorizontalTimeAxis
-                time={self.time.to_owned()} time_step={Duration::days(1)}
+            <HorizontalAxis
+                name="some-x-axis"
+                orientation={horizontal_axis::Orientation::Bottom}
+                scale={Rc::clone(&self.horizontal_axis_scale)}
                 x1={MARGIN} y1={HEIGHT - MARGIN} x2={WIDTH - MARGIN}
                 tick_len={TICK_LENGTH} />
 

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -6,12 +6,12 @@ use std::{
 use chrono::{Duration, Utc};
 use yew::prelude::*;
 use yew_chart::{
-    horizontal_series::{self, HorizontalSeries, SeriesData, SeriesDataLabelled},
-    horizontal_axis::{self, HorizontalAxis},
-    time_axis_scale::TimeAxisScale,
-    linear_axis_scale::LinearAxisScale,
-    vertical_axis::{self, VerticalAxis},
     axis::AxisScale,
+    horizontal_axis::{self, HorizontalAxis},
+    horizontal_series::{self, HorizontalSeries, SeriesData, SeriesDataLabelled},
+    linear_axis_scale::LinearAxisScale,
+    time_axis_scale::TimeAxisScale,
+    vertical_axis::{self, VerticalAxis},
 };
 
 const WIDTH: u32 = 533;
@@ -48,8 +48,8 @@ impl Component for App {
                 5.0,
                 horizontal_series::label("Label"),
             )]),
-            horizontal_axis_scale: Rc::new(TimeAxisScale::for_range(time, Duration::days(1), None)),
-            vertical_axis_scale: Rc::new(LinearAxisScale::for_range(0.0..5.0, 0.5))
+            horizontal_axis_scale: Rc::new(TimeAxisScale::new(time, Duration::days(1))),
+            vertical_axis_scale: Rc::new(LinearAxisScale::new(0.0..5.0, 1.0)),
         }
     }
 
@@ -77,7 +77,7 @@ impl Component for App {
                     x1={MARGIN} y1={MARGIN} y2={HEIGHT - MARGIN}
                     tick_len={TICK_LENGTH}
                     title={"Some Y thing".to_string()} />
-                    
+
                 <HorizontalAxis
                     name="some-x-axis"
                     orientation={horizontal_axis::Orientation::Bottom}

--- a/examples/scatter/src/main.rs
+++ b/examples/scatter/src/main.rs
@@ -6,12 +6,12 @@ use std::{
 use chrono::{Duration, Utc};
 use yew::prelude::*;
 use yew_chart::{
-    horizontal_series::{self, HorizontalSeries, SeriesData, SeriesDataLabelled},
-    horizontal_axis::{self, HorizontalAxis},
-    time_axis_scale::TimeAxisScale,
-    linear_axis_scale::LinearAxisScale,
-    vertical_axis::{self, VerticalAxis},
     axis::AxisScale,
+    horizontal_axis::{self, HorizontalAxis},
+    horizontal_series::{self, HorizontalSeries, SeriesData, SeriesDataLabelled},
+    linear_axis_scale::LinearAxisScale,
+    time_axis_scale::TimeAxisScale,
+    vertical_axis::{self, VerticalAxis},
 };
 
 const WIDTH: u32 = 533;
@@ -64,8 +64,8 @@ impl Component for App {
                     horizontal_series::label("Label"),
                 ),
             ]),
-            horizontal_axis_scale: Rc::new(TimeAxisScale::for_range(time, Duration::days(1), None)),
-            vertical_axis_scale: Rc::new(LinearAxisScale::for_range(0.0..5.0, 0.5))
+            horizontal_axis_scale: Rc::new(TimeAxisScale::new(time, Duration::days(1))),
+            vertical_axis_scale: Rc::new(LinearAxisScale::new(0.0..5.0, 1.0)),
         }
     }
 
@@ -93,7 +93,7 @@ impl Component for App {
                     x1={MARGIN} y1={MARGIN} y2={HEIGHT - MARGIN}
                     tick_len={TICK_LENGTH}
                     title={"Some Y thing".to_string()} />
-                    
+
                 <HorizontalAxis
                     name="some-x-axis"
                     orientation={horizontal_axis::Orientation::Bottom}

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -1,5 +1,6 @@
 /// Axis scaled value, expected to be between 0 and 1
 /// except in the case where the value is outside of the axis range
+#[derive(Debug, PartialEq)]
 pub struct NormalisedValue(pub f32);
 
 /// Specifies a generic scale on which axes and data can be rendered
@@ -20,11 +21,12 @@ pub trait AxisScale {
 
 /// An axis tick, specifying a label to be displayed at some normalised
 /// position along the axis
+#[derive(Debug, PartialEq)]
 pub struct AxisTick {
     /// normalised location between zero and one along the axis specifying
     /// the position at which the tick should be rendered
     pub location: NormalisedValue,
 
-    /// text label that should be rendered alongside the tick
+    /// The label that should be rendered alongside the tick
     pub label: String,
 }

--- a/src/linear_axis_scale.rs
+++ b/src/linear_axis_scale.rs
@@ -1,21 +1,43 @@
 /// A LinearAxisScale represents a linear scale for floating point values within a fixed range.
 /// A step is also expressed and indicates the interval to be used for each tick on the axis.
-use std::ops::Range;
+use std::{ops::Range, rc::Rc};
 
 use crate::axis::{AxisScale, AxisTick, NormalisedValue};
+
+/// An axis labeller is a closure that produces a string given a value within the axis scale
+pub type Labeller = dyn Fn(f32) -> String;
+
+fn labeller() -> Box<Labeller> {
+    Box::new(move |v| (v as u32).to_string())
+}
 
 #[derive(Clone)]
 pub struct LinearAxisScale {
     range: Range<f32>,
     step: f32,
     scale: f32,
+    labeller: Rc<Labeller>,
 }
 
 impl LinearAxisScale {
-    pub fn for_range(range: Range<f32>, step: f32) -> LinearAxisScale {
-        let scale = 1.0 / (range.end - range.start);
+    /// Create a new scale with a range and step and labels as a integers
+    pub fn new(range: Range<f32>, step: f32) -> LinearAxisScale {
+        Self::with_labeller(range, step, Rc::new(labeller()))
+    }
 
-        LinearAxisScale { range, step, scale }
+    /// Create a new scale with a range and step and a custom labeller
+    pub fn with_labeller(
+        range: Range<f32>,
+        step: f32,
+        labeller: Rc<Box<Labeller>>,
+    ) -> LinearAxisScale {
+        let scale = 1.0 / (range.end - range.start);
+        LinearAxisScale {
+            range,
+            step,
+            scale,
+            labeller,
+        }
     }
 }
 
@@ -31,7 +53,7 @@ impl AxisScale for LinearAxisScale {
                 let value = scale.range.start + (i as f32 * scale.step);
                 AxisTick {
                     location: NormalisedValue(location),
-                    label: value.to_string(),
+                    label: (self.labeller)(value),
                 }
             })
             .collect()
@@ -39,5 +61,43 @@ impl AxisScale for LinearAxisScale {
 
     fn normalise(&self, value: f32) -> NormalisedValue {
         NormalisedValue((value - self.range.start) * self.scale)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scale() {
+        let scale = LinearAxisScale::new(0.0..100.0, 25.0);
+
+        assert_eq!(
+            scale.ticks(),
+            vec![
+                AxisTick {
+                    location: NormalisedValue(0.0),
+                    label: "0".to_string()
+                },
+                AxisTick {
+                    location: NormalisedValue(0.25),
+                    label: "25".to_string()
+                },
+                AxisTick {
+                    location: NormalisedValue(0.5),
+                    label: "50".to_string()
+                },
+                AxisTick {
+                    location: NormalisedValue(0.75),
+                    label: "75".to_string()
+                },
+                AxisTick {
+                    location: NormalisedValue(1.0),
+                    label: "100".to_string()
+                }
+            ]
+        );
+
+        assert_eq!(scale.normalise(50.0), NormalisedValue(0.5));
     }
 }


### PR DESCRIPTION
Now provides for custom axis labels. Some re-factoring of constructor names also occurred given Rust style conventions. Added some tests too.

Fixes #11 