### PR TITLE
Floating point coords

### DIFF
--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -14,10 +14,10 @@ use yew_chart::{
     vertical_axis::{self, VerticalAxis},
 };
 
-const WIDTH: u32 = 533;
-const HEIGHT: u32 = 300;
-const MARGIN: u32 = 50;
-const TICK_LENGTH: u32 = 10;
+const WIDTH: f32 = 533.0;
+const HEIGHT: f32 = 300.0;
+const MARGIN: f32 = 50.0;
+const TICK_LENGTH: f32 = 10.0;
 
 struct App {
     data_set: Rc<SeriesData>,
@@ -68,7 +68,7 @@ impl Component for App {
                     horizontal_scale={Rc::clone(&self.horizontal_axis_scale)}
                     horizontal_scale_step={Duration::days(2).num_seconds() as f32}
                     vertical_scale={Rc::clone(&self.vertical_axis_scale)}
-                    x={MARGIN} y={MARGIN} width={WIDTH - (MARGIN * 2)} height={HEIGHT - (MARGIN * 2)} />
+                    x={MARGIN} y={MARGIN} width={WIDTH - (MARGIN * 2.0)} height={HEIGHT - (MARGIN * 2.0)} />
 
                 <VerticalAxis
                     name="some-y-axis"

--- a/examples/scatter/src/main.rs
+++ b/examples/scatter/src/main.rs
@@ -14,10 +14,10 @@ use yew_chart::{
     vertical_axis::{self, VerticalAxis},
 };
 
-const WIDTH: u32 = 533;
-const HEIGHT: u32 = 300;
-const MARGIN: u32 = 50;
-const TICK_LENGTH: u32 = 10;
+const WIDTH: f32 = 533.0;
+const HEIGHT: f32 = 300.0;
+const MARGIN: f32 = 50.0;
+const TICK_LENGTH: f32 = 10.0;
 
 struct App {
     data_set: Rc<SeriesData>,
@@ -84,7 +84,7 @@ impl Component for App {
                     horizontal_scale={Rc::clone(&self.horizontal_axis_scale)}
                     horizontal_scale_step={Duration::days(2).num_seconds() as f32}
                     vertical_scale={Rc::clone(&self.vertical_axis_scale)}
-                    x={MARGIN} y={MARGIN} width={WIDTH - (MARGIN * 2)} height={HEIGHT - (MARGIN * 2)} />
+                    x={MARGIN} y={MARGIN} width={WIDTH - (MARGIN * 2.0)} height={HEIGHT - (MARGIN * 2.0)} />
 
                 <VerticalAxis
                     name="some-y-axis"

--- a/src/horizontal_axis.rs
+++ b/src/horizontal_axis.rs
@@ -33,10 +33,10 @@ pub enum Orientation {
 pub struct Props {
     pub name: String,
     pub orientation: Orientation,
-    pub x1: u32,
-    pub x2: u32,
-    pub y1: u32,
-    pub tick_len: u32,
+    pub x1: f32,
+    pub x2: f32,
+    pub y1: f32,
+    pub tick_len: f32,
     pub title: Option<String>,
     pub scale: Rc<dyn AxisScale>,
 }
@@ -108,18 +108,18 @@ impl Component for HorizontalAxis {
                     html! {
                     <>
                         <line x1={x.to_string()} y1={y.to_string()} x2={x.to_string()} y2={to_y.to_string()} class="tick" />
-                        <text x={(x + 1.0).to_string()} y={to_y.to_string()} text-anchor="start" transform-origin={format!("{} {}", x, to_y + 1)} class="text">{label.to_string()}</text>
+                        <text x={(x + 1.0).to_string()} y={to_y.to_string()} text-anchor="start" transform-origin={format!("{} {}", x, to_y + 1.0)} class="text">{label.to_string()}</text>
                     </>
                     }
                 }) }
                 { for p.title.as_ref().map(|t| {
-                    let title_distance = p.tick_len << 1;
+                    let title_distance = p.tick_len * 2.0;
                     let y = if p.orientation == Orientation::Top {
                         p.y1 - title_distance
                     } else {
                         p.y1 + title_distance
                     };
-                    let x = p.x1 + ((p.x2 - p.x1) >> 1);
+                    let x = p.x1 + ((p.x2 - p.x1) * 0.5);
                     html! {
                         <text
                             x={x.to_string()} y={y.to_string()}
@@ -142,8 +142,8 @@ impl Component for HorizontalAxis {
             .and_then(|n| n.dyn_into::<SvgElement>().ok())
         {
             let width = svg_element.get_bounding_client_rect().width() as f32;
-            let scale = (p.x2 - p.x1) as f32 / width;
-            let font_size = scale * 100f32;
+            let scale = (p.x2 - p.x1) / width;
+            let font_size = scale * 100.0;
             let _ = element.set_attribute("font-size", &format!("{}%", &font_size));
             let _ = element.set_attribute("style", &format!("stroke-width: {}", scale));
         }

--- a/src/vertical_axis.rs
+++ b/src/vertical_axis.rs
@@ -33,10 +33,10 @@ pub enum Orientation {
 pub struct Props {
     pub name: String,
     pub orientation: Orientation,
-    pub x1: u32,
-    pub y1: u32,
-    pub y2: u32,
-    pub tick_len: u32,
+    pub x1: f32,
+    pub y1: f32,
+    pub y2: f32,
+    pub tick_len: f32,
     pub title: Option<String>,
     pub scale: Rc<dyn AxisScale>,
 }
@@ -113,13 +113,13 @@ impl Component for VerticalAxis {
                     }
                 }) }
                 { for p.title.as_ref().map(|t| {
-                    let title_distance = p.tick_len << 1;
+                    let title_distance = p.tick_len * 2.0;
                     let (x, rotation) = if p.orientation == Orientation::Left {
                         (p.x1 - title_distance, 270)
                     } else {
                         (p.x1 + title_distance, 90)
                     };
-                    let y = p.y1 + ((p.y2 - p.y1) >> 1);
+                    let y = p.y1 + ((p.y2 - p.y1) * 0.5);
                     html! {
                         <text
                             x={x.to_string()} y={y.to_string()}
@@ -143,8 +143,8 @@ impl Component for VerticalAxis {
             .and_then(|n| n.dyn_into::<SvgElement>().ok())
         {
             let height = svg_element.get_bounding_client_rect().height() as f32;
-            let scale = (p.y2 - p.y1) as f32 / height;
-            let font_size = scale * 100f32;
+            let scale = (p.y2 - p.y1) / height;
+            let font_size = scale * 100.0;
             let _ = element.set_attribute("font-size", &format!("{}%", &font_size));
             let _ = element.set_attribute("style", &format!("stroke-width: {}", scale));
         }


### PR DESCRIPTION
I originally used u32 for coords for performance. This was a premature optimisation and also reduces precision, along with not allowing for negative values (which are valid).

The changes here also fix some problems with margins where arithmetic could overflow. Margins aren't a construct of the chart components, but something that the calling program formulates. For example, the basic example program sets a margin of 50.0. This value is used to calculate the positioning and dimensions of inner components, but is not passed onto these inner components. For fun, you can set the margin constant to 0.0 and then see all axis text and ticks disappear.

Fixes #10 