### PR TITLE
Conflates data series labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,33 +74,7 @@ Using the same Yew view method code as above, `series_type` within the `Horizont
 
 ### Scatter Plot
 
-`examples/scatter` is configured to output a basic scatter plot. The method by which this is accomplished is slightly different to that of the `Line` and `Bar` charts.
-
-Instead of using the separate `SeriesType` key to select a scatter plot, the scatter plot is created by taking advantage of the `data_labels` property within `HorizontalSeries`.
-
-Since each label by default is composed of a circle and a textbox, a dataset of labels is created within `main.rs`, where for each datapoint that <em>shouldn't</em> have a label, that label is left empty.
-
-```rust
-//A label that will only show a point
-(
-    start_date.timestamp() as f32,
-    1.0,
-    horizontal_series::label(""),
-),
-
-//A label with text "Label"
-(
-    start_date.add(Duration::days(4)).timestamp() as f32,
-    5.0,
-    horizontal_series::label("Label"),
-),
-```
-
-As such, the scatter plot is a series of labels, rather than a specific dataset.
-
-<p align="center"><img src="./images/scatter-plot.png" alt="A scatter plot" width="70%" /></p>
-
-If it is desired that a `Line` or `Bar` chart be added to the scatter plot, this may be added by providing data in `data_set`, as in the previous examples.
+`examples/scatter` is configured to output a basic scatter plot. The method by which this is accomplished is slightly different to that of the `Line` and `Bar` charts. The labeller is relied upon for scatter plots.
 
 ## Contribution policy
 

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -8,7 +8,7 @@ use yew::prelude::*;
 use yew_chart::{
     axis::AxisScale,
     horizontal_axis::{self, HorizontalAxis},
-    horizontal_series::{self, HorizontalSeries, SeriesData, SeriesDataLabelled},
+    horizontal_series::{self, HorizontalSeries, SeriesData},
     linear_axis_scale::LinearAxisScale,
     time_axis_scale::TimeAxisScale,
     vertical_axis::{self, VerticalAxis},
@@ -21,7 +21,6 @@ const TICK_LENGTH: f32 = 10.0;
 
 struct App {
     data_set: Rc<SeriesData>,
-    data_set_labels: Rc<SeriesDataLabelled>,
     vertical_axis_scale: Rc<dyn AxisScale>,
     horizontal_axis_scale: Rc<dyn AxisScale>,
 }
@@ -35,19 +34,33 @@ impl Component for App {
         let end_date = Utc::now();
         let start_date = end_date.sub(Duration::days(4));
         let time = start_date..end_date;
+
+        let circle_text_labeller = Rc::from(horizontal_series::circle_text_label("Label"));
+
         App {
             data_set: Rc::new(vec![
-                (start_date.timestamp() as f32, 1.0),
-                (start_date.add(Duration::days(1)).timestamp() as f32, 4.0),
-                (start_date.add(Duration::days(2)).timestamp() as f32, 3.0),
-                (start_date.add(Duration::days(3)).timestamp() as f32, 2.0),
-                (start_date.add(Duration::days(4)).timestamp() as f32, 5.0),
+                (start_date.timestamp() as f32, 1.0, None),
+                (
+                    start_date.add(Duration::days(1)).timestamp() as f32,
+                    4.0,
+                    None,
+                ),
+                (
+                    start_date.add(Duration::days(2)).timestamp() as f32,
+                    3.0,
+                    None,
+                ),
+                (
+                    start_date.add(Duration::days(3)).timestamp() as f32,
+                    2.0,
+                    None,
+                ),
+                (
+                    start_date.add(Duration::days(4)).timestamp() as f32,
+                    5.0,
+                    Some(circle_text_labeller),
+                ),
             ]),
-            data_set_labels: Rc::new(vec![(
-                start_date.add(Duration::days(4)).timestamp() as f32,
-                5.0,
-                horizontal_series::label("Label"),
-            )]),
             horizontal_axis_scale: Rc::new(TimeAxisScale::new(time, Duration::days(1))),
             vertical_axis_scale: Rc::new(LinearAxisScale::new(0.0..5.0, 1.0)),
         }
@@ -64,7 +77,6 @@ impl Component for App {
                     series_type={horizontal_series::SeriesType::Line}
                     name="some-series"
                     data={Rc::clone(&self.data_set)}
-                    data_labels={Some(Rc::clone(&self.data_set_labels))}
                     horizontal_scale={Rc::clone(&self.horizontal_axis_scale)}
                     horizontal_scale_step={Duration::days(2).num_seconds() as f32}
                     vertical_scale={Rc::clone(&self.vertical_axis_scale)}

--- a/examples/scatter/index.scss
+++ b/examples/scatter/index.scss
@@ -37,6 +37,11 @@
     stroke: green;
     stroke-width: 2px;
 
+    circle {
+      fill: green;
+      stroke-width: 0px;
+    }
+
     text {
       stroke: none;
       stroke-width: 1px;

--- a/examples/scatter/src/main.rs
+++ b/examples/scatter/src/main.rs
@@ -8,7 +8,7 @@ use yew::prelude::*;
 use yew_chart::{
     axis::AxisScale,
     horizontal_axis::{self, HorizontalAxis},
-    horizontal_series::{self, HorizontalSeries, SeriesData, SeriesDataLabelled},
+    horizontal_series::{self, HorizontalSeries, SeriesData},
     linear_axis_scale::LinearAxisScale,
     time_axis_scale::TimeAxisScale,
     vertical_axis::{self, VerticalAxis},
@@ -21,7 +21,6 @@ const TICK_LENGTH: f32 = 10.0;
 
 struct App {
     data_set: Rc<SeriesData>,
-    data_set_labels: Rc<SeriesDataLabelled>,
     vertical_axis_scale: Rc<dyn AxisScale>,
     horizontal_axis_scale: Rc<dyn AxisScale>,
 }
@@ -35,33 +34,32 @@ impl Component for App {
         let end_date = Utc::now();
         let start_date = end_date.sub(Duration::days(4));
         let time = start_date..end_date;
+
+        let circle_labeller = Rc::from(horizontal_series::circle_label());
+        let circle_text_labeller = Rc::from(horizontal_series::circle_text_label("Label"));
+
         App {
-            data_set: Rc::new(vec![]),
-            data_set_labels: Rc::new(vec![
-                (
-                    start_date.timestamp() as f32,
-                    1.0,
-                    horizontal_series::label(""),
-                ),
+            data_set: Rc::new(vec![
+                (start_date.timestamp() as f32, 1.0, None),
                 (
                     start_date.add(Duration::days(1)).timestamp() as f32,
                     4.0,
-                    horizontal_series::label(""),
+                    Some(Rc::clone(&circle_labeller)),
                 ),
                 (
                     start_date.add(Duration::days(2)).timestamp() as f32,
                     3.0,
-                    horizontal_series::label(""),
+                    Some(Rc::clone(&circle_labeller)),
                 ),
                 (
                     start_date.add(Duration::days(3)).timestamp() as f32,
                     2.0,
-                    horizontal_series::label(""),
+                    Some(circle_labeller),
                 ),
                 (
                     start_date.add(Duration::days(4)).timestamp() as f32,
                     5.0,
-                    horizontal_series::label("Label"),
+                    Some(circle_text_labeller),
                 ),
             ]),
             horizontal_axis_scale: Rc::new(TimeAxisScale::new(time, Duration::days(1))),
@@ -77,10 +75,9 @@ impl Component for App {
         html! {
             <svg class="chart" viewBox={format!("0 0 {} {}", WIDTH, HEIGHT)} preserveAspectRatio="none">
                 <HorizontalSeries
-                    series_type={horizontal_series::SeriesType::Line}
+                    series_type={horizontal_series::SeriesType::Scatter}
                     name="some-series"
                     data={Rc::clone(&self.data_set)}
-                    data_labels={Some(Rc::clone(&self.data_set_labels))}
                     horizontal_scale={Rc::clone(&self.horizontal_axis_scale)}
                     horizontal_scale_step={Duration::days(2).num_seconds() as f32}
                     vertical_scale={Rc::clone(&self.vertical_axis_scale)}


### PR DESCRIPTION
Data series labels are now an optional component of a data series point. This makes the API simpler and hopefully, a little more obvious. I've also added a new series type of Scatter to signify that labels are relied on, along with a default circle and circle/text label.