### PR TITLE
Labels should be optional

### DIFF
--- a/src/axis.rs
+++ b/src/axis.rs
@@ -27,6 +27,6 @@ pub struct AxisTick {
     /// the position at which the tick should be rendered
     pub location: NormalisedValue,
 
-    /// The label that should be rendered alongside the tick
-    pub label: String,
+    /// An optional label that should be rendered alongside the tick
+    pub label: Option<String>,
 }

--- a/src/horizontal_axis.rs
+++ b/src/horizontal_axis.rs
@@ -108,7 +108,9 @@ impl Component for HorizontalAxis {
                     html! {
                     <>
                         <line x1={x.to_string()} y1={y.to_string()} x2={x.to_string()} y2={to_y.to_string()} class="tick" />
-                        <text x={x.to_string()} y={to_y.to_string()} text-anchor="middle" transform-origin={format!("{} {}", x, to_y)} dominant-baseline={baseline.to_string()} class="text">{label.to_string()}</text>
+                        if let Some(l) = label {
+                            <text x={x.to_string()} y={to_y.to_string()} text-anchor="middle" transform-origin={format!("{} {}", x, to_y)} dominant-baseline={baseline.to_string()} class="text">{l.to_string()}</text>
+                        }
                     </>
                     }
                 }) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
+/// yew-chart is a collection of components that can be assembled to form charts.
+/// By leveraging these SVG-based components many types of charts can be formed
+/// with a great deal of flexibility.
 pub mod axis;
 pub mod horizontal_axis;
 pub mod horizontal_series;
 pub mod linear_axis_scale;
-/// yew-chart is a collection of components that can be assembled to form charts.
-/// By leveraging these SVG-based components many types of charts can be formed
-/// with a great deal of flexibility.
 pub mod time_axis_scale;
 pub mod vertical_axis;

--- a/src/linear_axis_scale.rs
+++ b/src/linear_axis_scale.rs
@@ -16,20 +16,20 @@ pub struct LinearAxisScale {
     range: Range<f32>,
     step: f32,
     scale: f32,
-    labeller: Rc<Labeller>,
+    labeller: Option<Rc<Labeller>>,
 }
 
 impl LinearAxisScale {
     /// Create a new scale with a range and step and labels as a integers
     pub fn new(range: Range<f32>, step: f32) -> LinearAxisScale {
-        Self::with_labeller(range, step, Rc::new(labeller()))
+        Self::with_labeller(range, step, Some(Rc::from(labeller())))
     }
 
     /// Create a new scale with a range and step and a custom labeller
     pub fn with_labeller(
         range: Range<f32>,
         step: f32,
-        labeller: Rc<Box<Labeller>>,
+        labeller: Option<Rc<Labeller>>,
     ) -> LinearAxisScale {
         let scale = 1.0 / (range.end - range.start);
         LinearAxisScale {
@@ -53,7 +53,7 @@ impl AxisScale for LinearAxisScale {
                 let value = scale.range.start + (i as f32 * scale.step);
                 AxisTick {
                     location: NormalisedValue(location),
-                    label: (self.labeller)(value),
+                    label: self.labeller.as_ref().map(|l| (l)(value)),
                 }
             })
             .collect()
@@ -77,23 +77,23 @@ mod tests {
             vec![
                 AxisTick {
                     location: NormalisedValue(0.0),
-                    label: "0".to_string()
+                    label: Some("0".to_string())
                 },
                 AxisTick {
                     location: NormalisedValue(0.25),
-                    label: "25".to_string()
+                    label: Some("25".to_string())
                 },
                 AxisTick {
                     location: NormalisedValue(0.5),
-                    label: "50".to_string()
+                    label: Some("50".to_string())
                 },
                 AxisTick {
                     location: NormalisedValue(0.75),
-                    label: "75".to_string()
+                    label: Some("75".to_string())
                 },
                 AxisTick {
                     location: NormalisedValue(1.0),
-                    label: "100".to_string()
+                    label: Some("100".to_string())
                 }
             ]
         );

--- a/src/time_axis_scale.rs
+++ b/src/time_axis_scale.rs
@@ -23,20 +23,20 @@ pub struct TimeAxisScale {
     time_to: i64,
     step: i64,
     scale: f32,
-    labeller: Rc<Labeller>,
+    labeller: Option<Rc<Labeller>>,
 }
 
 impl TimeAxisScale {
     /// Create a new scale with a range and step representing labels as a day and month in local time.
     pub fn new(range: Range<DateTime<Utc>>, step: Duration) -> TimeAxisScale {
-        Self::with_labeller(range, step, Rc::new(labeller()))
+        Self::with_labeller(range, step, Some(Rc::from(labeller())))
     }
 
     /// Create a new scale with a range and step and custom labeller.
     pub fn with_labeller(
         range: Range<DateTime<Utc>>,
         step: Duration,
-        labeller: Rc<Box<Labeller>>,
+        labeller: Option<Rc<Labeller>>,
     ) -> TimeAxisScale {
         let time_from = range.start.timestamp();
         let time_to = range.end.timestamp();
@@ -63,7 +63,7 @@ impl AxisScale for TimeAxisScale {
                 let location = (i - scale.time_from) as f32 * scale.scale;
                 AxisTick {
                     location: NormalisedValue(location),
-                    label: (self.labeller)(i),
+                    label: self.labeller.as_ref().map(|l| (l)(i)),
                 }
             })
             .collect()
@@ -92,23 +92,23 @@ mod tests {
             vec![
                 AxisTick {
                     location: NormalisedValue(0.0),
-                    label: "26-Feb".to_string()
+                    label: Some("26-Feb".to_string())
                 },
                 AxisTick {
                     location: NormalisedValue(0.25),
-                    label: "27-Feb".to_string()
+                    label: Some("27-Feb".to_string())
                 },
                 AxisTick {
                     location: NormalisedValue(0.5),
-                    label: "28-Feb".to_string()
+                    label: Some("28-Feb".to_string())
                 },
                 AxisTick {
                     location: NormalisedValue(0.75),
-                    label: "01-Mar".to_string()
+                    label: Some("01-Mar".to_string())
                 },
                 AxisTick {
                     location: NormalisedValue(1.0),
-                    label: "02-Mar".to_string()
+                    label: Some("02-Mar".to_string())
                 }
             ]
         );

--- a/src/vertical_axis.rs
+++ b/src/vertical_axis.rs
@@ -108,7 +108,9 @@ impl Component for VerticalAxis {
                     html! {
                     <>
                         <line x1={x.to_string()} y1={y.to_string()} x2={to_x.to_string()} y2={y.to_string()} class="tick" />
-                        <text x={to_x.to_string()} y={y.to_string()} text-anchor={if p.orientation == Orientation::Left {"end"} else {"start"}} class="text">{label.to_owned()}</text>
+                        if let Some(l) = label {
+                            <text x={to_x.to_string()} y={y.to_string()} text-anchor={if p.orientation == Orientation::Left {"end"} else {"start"}} class="text">{l.to_string()}</text>
+                        }
                     </>
                     }
                 }) }


### PR DESCRIPTION
Prior to this commit, labels could be empty but not optional. They are now optional which avoids providing a text element where they are not to be used.