### PR TITLE
Tooltips

### DIFF
--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -52,6 +52,8 @@ fn app() -> Html {
     let h_scale = Rc::new(TimeScale::new(timespan, Duration::days(1))) as Rc<dyn Scale>;
     let v_scale = Rc::new(LinearScale::new(0.0..5.0, 1.0)) as Rc<dyn Scale>;
 
+    let tooltip = Rc::from(series::y_tooltip());
+
     html! {
             <svg class="chart" viewBox={format!("0 0 {} {}", WIDTH, HEIGHT)} preserveAspectRatio="none">
                 <Series
@@ -60,6 +62,7 @@ fn app() -> Html {
                     data={data_set}
                     horizontal_scale={Rc::clone(&h_scale)}
                     horizontal_scale_step={Duration::days(2).num_milliseconds() as f32}
+                    tooltipper={Rc::clone(&tooltip)}
                     vertical_scale={Rc::clone(&v_scale)}
                     x={MARGIN} y={MARGIN} width={WIDTH - (MARGIN * 2.0)} height={HEIGHT - (MARGIN * 2.0)} />
 


### PR DESCRIPTION
Tooltips can now be optionally provided for the bar and line charts. The tooltips are rendered as <title> elements within these lines.

Scatter charts are not catered for as there is no svg container element such as a line. However, given that scatter charts are rendered using labels, the labels themselves can include their own <title> element if required.