### PR TITLE
Custom tooltip support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,8 @@ features = [
     "Element",
     "SvgElement",
 ]
+
+[features]
+
+# Set when custom tooltips are to be used instead of browser based ones
+custom-tooltip = []


### PR DESCRIPTION
Provides the ability to capture onmouseover events for custom tooltips. To enable this, a `custom-tooltip` feature is required to be set. This then replaces code that relies on browser behaviour to call an onmouseover callback instead. The user's onmouseover callback is provided with the original mouse event and a formatted string (the result of the tooltipper function).