### PR TITLE
Remove unnecessary boxes

### DIFF
--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -8,7 +8,7 @@ use yew::prelude::*;
 use yew_chart::{
     axis::{Axis, Orientation, Scale},
     linear_axis_scale::LinearScale,
-    series::{self, Series, Type},
+    series::{self, Labeller, Series, Tooltipper, Type},
     time_axis_scale::TimeScale,
 };
 
@@ -23,7 +23,7 @@ fn app() -> Html {
     let start_date = end_date.sub(Duration::days(4));
     let timespan = start_date..end_date;
 
-    let circle_text_labeller = Rc::from(series::circle_text_label("Label"));
+    let circle_text_labeller = Rc::from(series::circle_text_label("Label")) as Rc<dyn Labeller>;
 
     let data_set = Rc::new(vec![
         (start_date.timestamp_millis() as f32, 1.0, None),
@@ -52,7 +52,7 @@ fn app() -> Html {
     let h_scale = Rc::new(TimeScale::new(timespan, Duration::days(1))) as Rc<dyn Scale>;
     let v_scale = Rc::new(LinearScale::new(0.0..5.0, 1.0)) as Rc<dyn Scale>;
 
-    let tooltip = Rc::from(series::y_tooltip());
+    let tooltip = Rc::from(series::y_tooltip()) as Rc<dyn Tooltipper>;
 
     html! {
             <svg class="chart" viewBox={format!("0 0 {} {}", WIDTH, HEIGHT)} preserveAspectRatio="none">

--- a/examples/scatter/src/main.rs
+++ b/examples/scatter/src/main.rs
@@ -8,7 +8,7 @@ use yew::prelude::*;
 use yew_chart::{
     axis::{Axis, Orientation, Scale},
     linear_axis_scale::LinearScale,
-    series::{self, Data, Series, Type},
+    series::{self, Data, Labeller, Series, Type},
     time_axis_scale::TimeScale,
 };
 
@@ -33,8 +33,8 @@ impl Component for App {
         let start_date = end_date.sub(Duration::days(4));
         let time = start_date..end_date;
 
-        let circle_labeller = Rc::from(series::circle_label());
-        let circle_text_labeller = Rc::from(series::circle_text_label("Label"));
+        let circle_labeller = Rc::from(series::circle_label()) as Rc<dyn Labeller>;
+        let circle_text_labeller = Rc::from(series::circle_text_label("Label")) as Rc<dyn Labeller>;
 
         App {
             data_set: Rc::new(vec![


### PR DESCRIPTION
We now return `impl <Trait>`  in place of boxing so we can avoid an additional allocation. Upon reading around the forums, this is the more conventional way to return a closure.

@avonow Note that this will require a few `as Rc<dyn Labeller>`, `as Rc<dyn Tooltipper>` coercions and removals of `Box::new`. I can help with that.