### PR TITLE
Circumvents a proc-macro issue with RA

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.diagnostics.disabled": [
+        "unresolved-proc-macro"
+    ]
+}


### PR DESCRIPTION
Rust Analyzer appears to be incorrectly reporting a proc macro error. The settings here works-around the issue.

See https://github.com/rust-lang/rust-analyzer/issues/6835 to track the issue.