### PR TITLE
Introduces a Scalar trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,37 +43,37 @@ fn app() -> Html {
     let circle_text_labeller = Rc::from(series::circle_text_label("Label")) as Rc<dyn Labeller>;
 
     let data_set = Rc::new(vec![
-        (start_date.timestamp_millis() as f32, 1.0, None),
+        (start_date.timestamp_millis(), 1.0, None),
         (
-            start_date.add(Duration::days(1)).timestamp_millis() as f32,
+            start_date.add(Duration::days(1)).timestamp_millis(),
             4.0,
             None,
         ),
         (
-            start_date.add(Duration::days(2)).timestamp_millis() as f32,
+            start_date.add(Duration::days(2)).timestamp_millis(),
             3.0,
             None,
         ),
         (
-            start_date.add(Duration::days(3)).timestamp_millis() as f32,
+            start_date.add(Duration::days(3)).timestamp_millis(),
             2.0,
             None,
         ),
         (
-            start_date.add(Duration::days(4)).timestamp_millis() as f32,
+            start_date.add(Duration::days(4)).timestamp_millis(),
             5.0,
             Some(circle_text_labeller),
         ),
     ]);
 
-    let h_scale = Rc::new(TimeScale::new(timespan, Duration::days(1))) as Rc<dyn Scale>;
-    let v_scale = Rc::new(LinearScale::new(0.0..5.0, 1.0)) as Rc<dyn Scale>;
+    let h_scale = Rc::new(TimeScale::new(timespan, Duration::days(1))) as Rc<dyn Scale<Scalar = _>>;
+    let v_scale = Rc::new(LinearScale::new(0.0..5.0, 1.0)) as Rc<dyn Scale<Scalar = _>>;
 
-    let tooltip = Rc::from(series::y_tooltip()) as Rc<dyn Tooltipper>;
+    let tooltip = Rc::from(series::y_tooltip()) as Rc<dyn Tooltipper<_, _>>;
 
     html! {
             <svg class="chart" viewBox={format!("0 0 {} {}", WIDTH, HEIGHT)} preserveAspectRatio="none">
-                <Series
+                <Series<i64, f32>
                     series_type={Type::Line}
                     name="some-series"
                     data={data_set}
@@ -83,7 +83,7 @@ fn app() -> Html {
                     vertical_scale={Rc::clone(&v_scale)}
                     x={MARGIN} y={MARGIN} width={WIDTH - (MARGIN * 2.0)} height={HEIGHT - (MARGIN * 2.0)} />
 
-                <Axis
+                <Axis<f32>
                     name="some-y-axis"
                     orientation={Orientation::Left}
                     scale={Rc::clone(&v_scale)}
@@ -91,7 +91,7 @@ fn app() -> Html {
                     tick_len={TICK_LENGTH}
                     title={"Some Y thing".to_string()} />
 
-                <Axis
+                <Axis<i64>
                     name="some-x-axis"
                     orientation={Orientation::Bottom}
                     scale={Rc::clone(&h_scale)}
@@ -111,11 +111,6 @@ fn app() -> Html {
 >
 > That all said, you probably won't be passing `SeriesData` around via props, but some other `Rc` of a model oriented data type
 > which is to be mapped to it. Using `ptr_eq` is still the way to go there though as you'll get performance benefits.
-
-> A note on dealing with time... yew-chart operates with 32 bit in mind given that it is expected to work well for all
-> WASM targets. As such, coercing i64 timestamps to f32 values will lose precision and round. When dealing with high precision,
-> we recommend that you scale the axis accordingly. The examples/scatter illustrates how milliseconds can be represented by taking
-> the bottom 24 bits of a timestamp.
 
 ### Bar Chart
 
@@ -145,8 +140,7 @@ One final example of this is in using a negative scale and negative values. In t
 
 ### Scatter Plot
 
-`examples/scatter` is configured to output a basic scatter plot. The method by which this is accomplished is slightly different to that of the `Line` and `Bar` charts. The example
-also provides an illustration of how to handle high resolution time.
+`examples/scatter` is configured to output a basic scatter plot. The method by which this is accomplished is slightly different to that of the `Line` and `Bar` charts.
 
 ## Contribution policy
 

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -26,37 +26,37 @@ fn app() -> Html {
     let circle_text_labeller = Rc::from(series::circle_text_label("Label")) as Rc<dyn Labeller>;
 
     let data_set = Rc::new(vec![
-        (start_date.timestamp_millis() as f32, 1.0, None),
+        (start_date.timestamp_millis(), 1.0, None),
         (
-            start_date.add(Duration::days(1)).timestamp_millis() as f32,
+            start_date.add(Duration::days(1)).timestamp_millis(),
             4.0,
             None,
         ),
         (
-            start_date.add(Duration::days(2)).timestamp_millis() as f32,
+            start_date.add(Duration::days(2)).timestamp_millis(),
             3.0,
             None,
         ),
         (
-            start_date.add(Duration::days(3)).timestamp_millis() as f32,
+            start_date.add(Duration::days(3)).timestamp_millis(),
             2.0,
             None,
         ),
         (
-            start_date.add(Duration::days(4)).timestamp_millis() as f32,
+            start_date.add(Duration::days(4)).timestamp_millis(),
             5.0,
             Some(circle_text_labeller),
         ),
     ]);
 
-    let h_scale = Rc::new(TimeScale::new(timespan, Duration::days(1))) as Rc<dyn Scale>;
-    let v_scale = Rc::new(LinearScale::new(0.0..5.0, 1.0)) as Rc<dyn Scale>;
+    let h_scale = Rc::new(TimeScale::new(timespan, Duration::days(1))) as Rc<dyn Scale<Scalar = _>>;
+    let v_scale = Rc::new(LinearScale::new(0.0..5.0, 1.0)) as Rc<dyn Scale<Scalar = _>>;
 
-    let tooltip = Rc::from(series::y_tooltip()) as Rc<dyn Tooltipper>;
+    let tooltip = Rc::from(series::y_tooltip()) as Rc<dyn Tooltipper<_, _>>;
 
     html! {
             <svg class="chart" viewBox={format!("0 0 {} {}", WIDTH, HEIGHT)} preserveAspectRatio="none">
-                <Series
+                <Series<i64, f32>
                     series_type={Type::Line}
                     name="some-series"
                     data={data_set}
@@ -66,7 +66,7 @@ fn app() -> Html {
                     vertical_scale={Rc::clone(&v_scale)}
                     x={MARGIN} y={MARGIN} width={WIDTH - (MARGIN * 2.0)} height={HEIGHT - (MARGIN * 2.0)} />
 
-                <Axis
+                <Axis<f32>
                     name="some-y-axis"
                     orientation={Orientation::Left}
                     scale={Rc::clone(&v_scale)}
@@ -74,7 +74,7 @@ fn app() -> Html {
                     tick_len={TICK_LENGTH}
                     title={"Some Y thing".to_string()} />
 
-                <Axis
+                <Axis<i64>
                     name="some-x-axis"
                     orientation={Orientation::Bottom}
                     scale={Rc::clone(&h_scale)}

--- a/examples/scatter/src/main.rs
+++ b/examples/scatter/src/main.rs
@@ -18,10 +18,9 @@ const MARGIN: f32 = 50.0;
 const TICK_LENGTH: f32 = 10.0;
 
 struct App {
-    data_set: Rc<Data>,
-    vertical_axis_scale: Rc<dyn Scale>,
-    horizontal_axis_scale: Rc<dyn Scale>,
-    horizontal_series_scale: Rc<dyn Scale>,
+    data_set: Rc<Data<i64, f32>>,
+    vertical_axis_scale: Rc<dyn Scale<Scalar = f32>>,
+    horizontal_axis_scale: Rc<dyn Scale<Scalar = i64>>,
 }
 
 impl Component for App {
@@ -33,36 +32,30 @@ impl Component for App {
         let end_date = Utc::now();
         let start_date = end_date.sub(Duration::milliseconds(4));
         let time = start_date..end_date;
-        let series_time = (start_date.timestamp_millis() & 0xffffff) as f32
-            ..(end_date.timestamp_millis() & 0xffffff) as f32;
 
         let circle_labeller = Rc::from(series::circle_label()) as Rc<dyn Labeller>;
         let circle_text_labeller = Rc::from(series::circle_text_label("Label")) as Rc<dyn Labeller>;
 
         App {
             data_set: Rc::new(vec![
-                ((start_date.timestamp_millis() & 0xffffff) as f32, 1.0, None),
+                (start_date.timestamp_millis(), 1.0, None),
                 (
-                    (start_date.add(Duration::milliseconds(1)).timestamp_millis() & 0xffffff)
-                        as f32,
+                    start_date.add(Duration::milliseconds(1)).timestamp_millis(),
                     4.0,
                     Some(Rc::clone(&circle_labeller)),
                 ),
                 (
-                    (start_date.add(Duration::milliseconds(2)).timestamp_millis() & 0xffffff)
-                        as f32,
+                    start_date.add(Duration::milliseconds(2)).timestamp_millis(),
                     3.0,
                     Some(Rc::clone(&circle_labeller)),
                 ),
                 (
-                    (start_date.add(Duration::milliseconds(3)).timestamp_millis() & 0xffffff)
-                        as f32,
+                    start_date.add(Duration::milliseconds(3)).timestamp_millis(),
                     2.0,
                     Some(circle_labeller),
                 ),
                 (
-                    (start_date.add(Duration::milliseconds(4)).timestamp_millis() & 0xffffff)
-                        as f32,
+                    start_date.add(Duration::milliseconds(4)).timestamp_millis(),
                     5.0,
                     Some(circle_text_labeller),
                 ),
@@ -71,10 +64,6 @@ impl Component for App {
                 time,
                 Duration::milliseconds(1),
                 "%3f",
-            )),
-            horizontal_series_scale: Rc::new(LinearScale::new(
-                series_time,
-                Duration::milliseconds(1).num_milliseconds() as u32 as f32,
             )),
             vertical_axis_scale: Rc::new(LinearScale::new(0.0..5.0, 1.0)),
         }
@@ -87,15 +76,15 @@ impl Component for App {
     fn view(&self, _ctx: &Context<Self>) -> yew::Html {
         html! {
             <svg class="chart" viewBox={format!("0 0 {} {}", WIDTH, HEIGHT)} preserveAspectRatio="none">
-                <Series
+                <Series<i64, f32>
                     series_type={Type::Scatter}
                     name="some-series"
                     data={Rc::clone(&self.data_set)}
-                    horizontal_scale={Rc::clone(&self.horizontal_series_scale)}
+                    horizontal_scale={Rc::clone(&self.horizontal_axis_scale)}
                     vertical_scale={Rc::clone(&self.vertical_axis_scale)}
                     x={MARGIN} y={MARGIN} width={WIDTH - (MARGIN * 2.0)} height={HEIGHT - (MARGIN * 2.0)} />
 
-                <Axis
+                <Axis<f32>
                     name="some-y-axis"
                     orientation={Orientation::Left}
                     scale={Rc::clone(&self.vertical_axis_scale)}
@@ -103,7 +92,7 @@ impl Component for App {
                     tick_len={TICK_LENGTH}
                     title={"Some Y thing".to_string()} />
 
-                <Axis
+                <Axis<i64>
                     name="some-x-axis"
                     orientation={Orientation::Bottom}
                     scale={Rc::clone(&self.horizontal_axis_scale)}

--- a/src/linear_axis_scale.rs
+++ b/src/linear_axis_scale.rs
@@ -45,6 +45,8 @@ impl LinearScale {
 }
 
 impl Scale for LinearScale {
+    type Scalar = f32;
+
     fn ticks(&self) -> Vec<Tick> {
         LinearScaleInclusiveIter {
             from: self.range.start,
@@ -63,7 +65,7 @@ impl Scale for LinearScale {
         .collect()
     }
 
-    fn normalise(&self, value: f32) -> NormalisedValue {
+    fn normalise(&self, value: Self::Scalar) -> NormalisedValue {
         NormalisedValue((value - self.range.start) * self.scale)
     }
 }

--- a/src/time_axis_scale.rs
+++ b/src/time_axis_scale.rs
@@ -64,6 +64,8 @@ impl TimeScale {
 }
 
 impl Scale for TimeScale {
+    type Scalar = i64;
+
     fn ticks(&self) -> Vec<Tick> {
         TimeScaleInclusiveIter {
             time_from: self.time.start,
@@ -81,8 +83,8 @@ impl Scale for TimeScale {
         .collect()
     }
 
-    fn normalise(&self, value: f32) -> NormalisedValue {
-        NormalisedValue((value - (self.time.start as f32)) * self.scale)
+    fn normalise(&self, value: Self::Scalar) -> NormalisedValue {
+        NormalisedValue((value - self.time.start) as f32 * self.scale)
     }
 }
 
@@ -154,8 +156,8 @@ mod tests {
         );
 
         assert_eq!(
-            scale.normalise(end_date.sub(Duration::days(2)).timestamp_millis() as f32),
-            NormalisedValue(0.4998637)
+            scale.normalise(end_date.sub(Duration::days(2)).timestamp_millis()),
+            NormalisedValue(0.5)
         );
     }
 
@@ -193,8 +195,8 @@ mod tests {
         );
 
         assert_eq!(
-            scale.normalise(start_date.sub(Duration::days(2)).timestamp_millis() as f32),
-            NormalisedValue(0.50024295)
+            scale.normalise(start_date.sub(Duration::days(2)).timestamp_millis()),
+            NormalisedValue(0.5)
         );
     }
 
@@ -214,7 +216,7 @@ mod tests {
         );
 
         assert_eq!(
-            scale.normalise(end_date.timestamp_millis() as f32),
+            scale.normalise(end_date.timestamp_millis()),
             NormalisedValue(0.0)
         );
     }
@@ -229,7 +231,7 @@ mod tests {
         assert_eq!(scale.ticks(), vec![]);
 
         assert_eq!(
-            scale.normalise(end_date.timestamp_millis() as f32),
+            scale.normalise(end_date.timestamp_millis()),
             NormalisedValue(0.0)
         );
     }


### PR DESCRIPTION
Introduces a Scalar trait such that we can provide a data series containing both i64 timestamps and f32 values. Other types can be declared as required by the user, should they need to. However, i64 and f32 should cover the majority of requirements.